### PR TITLE
Fix ModuleNotFoundError: Add missing dependencies fpdf2 and yagmail

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ python-docx>=0.8.11
 reportlab>=4.0.0
 firecrawl-py>=0.0.8
 beautifulsoup4>=4.12.0
+fpdf2>=2.7.0
+yagmail>=0.15.0

--- a/requirements_fixed.txt
+++ b/requirements_fixed.txt
@@ -1,0 +1,16 @@
+streamlit>=1.28.0
+plotly>=5.15.0
+PyPDF2>=3.0.1
+requests>=2.31.0
+python-dotenv>=1.0.0
+google-generativeai>=0.3.0
+mistralai>=0.0.8
+email-validator>=2.0.0
+pandas>=2.0.0
+numpy>=1.24.0
+python-docx>=0.8.11
+reportlab>=4.0.0
+firecrawl-py>=0.0.8
+beautifulsoup4>=4.12.0
+fpdf2>=2.7.0
+yagmail>=0.15.0


### PR DESCRIPTION
## Problem Fixed
This PR resolves the `ModuleNotFoundError` that was preventing the Streamlit app from running.

## Changes Made
- ✅ Added `fpdf2>=2.7.0` to requirements.txt (for PDF generation in utils/exporter.py)
- ✅ Added `yagmail>=0.15.0` to requirements.txt (for email functionality in utils/exporter.py)

## Error Resolved
```
ModuleNotFoundError: No module named 'fpdf'
Traceback:
File "/mount/src/job-snipper/utils/exporter.py", line 1, in <module>
    from fpdf import FPDF
```

## Testing
After merging this PR:
1. Run `pip install -r requirements.txt` 
2. Your Streamlit app should start without ModuleNotFoundError

## Dependencies Added
- **fpdf2**: Modern, actively maintained PDF generation library (successor to fpdf)
- **yagmail**: Simple email sending library used in the exporter module

The app should now run successfully on Streamlit Cloud! 🚀